### PR TITLE
Update Template with content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 site
 .env
+*.ipynb_checkpoints/

--- a/docs/contributions.md
+++ b/docs/contributions.md
@@ -1,0 +1,40 @@
+# Contributions
+Hi! I am happy that you thought of contributing! If you have any suggestions or issues, please raise it [here](https://github.com/uwasystemhealth/shl-mkdocs-tutorial-and-template/issues). I would be happy if you could provide pull requests, if you know how to do it [here](https://github.com/uwasystemhealth/shl-mkdocs-tutorial-and-template/pulls). Also add your name in the contributors section.
+
+## Structure
+
+### Folder Structure
+The structure of this repo is as follows:
+
+```
+├── docs                    // Folders for documentation
+│   ├── CNAME
+│   ├── contributions.md
+│   ├── deployment_and_automated_site_deployment.md
+│   ├── flavoured_markdown.md
+│   ├── images              // Assets
+│   │   ├── shl.png
+│   │   └── shl_with_text.png
+│   ├── index.md
+│   └── writing_markdown.md
+├── LICENSE
+├── mkdocs.yml              // MkDocs Configuration
+├── overrides
+│   └── partials
+│       └── footer.html
+├── README.md
+└── requirements.txt
+```
+
+### Branch Structure
+You might have noticed that there are a couple of branches that are important:
+
+- `gh-pages` is the branch that contains the GitHub Pages build as per requirement of a website hosted in Github Pages
+- `main` is the branch that contains the `main` branch for any development and contribution
+- `template` is the branch that is in the front page of the Github Repo. This is the branch where all repositories will inherit the template.
+
+???+ info "Why have `template` and `main` separate?"
+    One of the things that you could see in `main` is the file called `CNAME` this is configuration for the domain name. Templates that inherit the files should not have this, otherwise there would be conflict in the organisation deployment for domain name.
+
+    Furthermore, by separating this, the changes could be version batched before releasing it in `template`.
+

--- a/docs/deployment_and_automated_site_deployment.md
+++ b/docs/deployment_and_automated_site_deployment.md
@@ -14,16 +14,6 @@ Just follow the prompt, and it will automatically deploy your website in github 
 1. Generation of website files
 2. Deployment with Github Pages
 
-### Custom Domain Name
-
-In the scenario that you like a custom domain name such as https://www.tutorial-mkdocs.systemhealthlab.com , follow this [documentation](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/about-custom-domains-and-github-pages).
-
-tldr (too long didn't read) instructions:
-1. Go to the domain registar, in my case Cloudflare
-2. Register a "CNAME" of the domain/subdomain going towards `<organisation/githubname>.github.io` (eg. `uwasystemhealth.github.io`)
-3. Add a `CNAME` file with the name of the domain/subdomain in the `/docs` folder
-4. Give the `CNAME` file a content of the subdomain name (eg. `tutorial-mkdocs.systemhealthlab.com`)
-
 ### Automatic Site Deployment with Github Action
 This is a configuration which allows your documentation from github to auto-deploy to the github pages. You might not want to run `mkdocs gh-deploy` everytime you have new changes.
 
@@ -111,6 +101,17 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site
 ```
+### Custom Domain Name
+
+In the scenario that you like a custom domain name such as https://www.tutorial-mkdocs.systemhealthlab.com , follow this [documentation](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/about-custom-domains-and-github-pages).
+
+Simplified instructions:
+
+1. Go to the domain registar, in my case Cloudflare
+2. Register a "CNAME" of the domain/subdomain going towards `<organisation/githubname>.github.io` (eg. `uwasystemhealth.github.io`)
+3. Add a `CNAME` file with the name of the domain/subdomain in the `/docs` folder
+4. Give the `CNAME` file a content of the subdomain name (eg. `tutorial-mkdocs.systemhealthlab.com`)
+
 
 ## Custom Site Deployment
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,8 +39,12 @@ This tutorial and template has 2 main purpose:
 5. Deploy somewhere ! (easiest way is with Github Pages see [here](#commands))
 
 
-??? note "Branch Name"
+???+ note "Branch Name"
     When you press "Use This template", the new repository will have "template" in its name. Change that in the Github >> Settings >> Branches >> Default Branch >> "Click the pencil icon".
+
+???+ info "Private Repositories Github Pages"
+    When you create a private repository, by default, your website will be flagged as "ready to be published". To publish the website, you have to go to Github >> Settings >> Pages >> "Change the Source Branch to `gh-pages`" >> Press Save
+
 ## Installation
 Install this preferably in your global environment because this is just a code generator and so.
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,13 +46,32 @@ This tutorial and template has 2 main purpose:
     When you create a private repository, by default, your website will be flagged as "ready to be published". To publish the website, you have to go to Github >> Settings >> Pages >> "Change the Source Branch to `gh-pages`" >> Press Save
 
 ## Installation
-Install this preferably in your global environment because this is just a code generator and so.
-```
-pip install -r requirements.txt
-```
 
 ???+ note "Prerequisite"
-    You need to make sure that you have Python installed to be able to use `pip`. Here is the download [link](https://www.python.org/downloads/).
+    You need to have Python installed to be able to use `pip`.
+    There are a few ways of installing Python.
+    You can use a package distributor like [Anaconda](https://www.anaconda.com/products/individual)
+    Or you can just install [Python](https://www.python.org/downloads/).
+
+
+Once you have installed Python, install mkdocs requirements by opening a terminal and typing:
+
+```bash
+pip install -r requirements.txt
+```
+??? info "Python Environments (Optional)"
+    however, it is good practice to use different environments for different purposes, in which case, for Anaconda, you would open a terminal and type:
+
+    ```bash
+    conda create -n mkdocstutorial python
+    conda activate mkdocstutorial
+    ```
+    then enter:
+
+    ```bash
+    pip install -r requirements.txt
+    ```
+
 ## Commands
 
 * `mkdocs new [dir-name]` - Create a new project.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,8 +37,10 @@ This tutorial and template has 2 main purpose:
 3. Change a couple of things in the `mkdocs.yml` file (there are comments around it to make it easier)
 4. Modify the `nav` in the `mkdocs.yml` file or delete it (Mkdocs will sort you documentation files to display)
 5. Deploy somewhere ! (easiest way is with Github Pages see [here](#commands))
-   
 
+
+??? note "Branch Name"
+    When you press "Use This template", the new repository will have "template" in its name. Change that in the Github >> Settings >> Branches >> Default Branch >> "Click the pencil icon".
 ## Installation
 Install this preferably in your global environment because this is just a code generator and so.
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,12 @@ For full documentation visit:
 - [PyMdown Extensions](https://facelessuser.github.io/pymdown-extensions/) for the different extensions that are installed
 - [MkDocs Material](https://squidfunk.github.io/mkdocs-material/) for the customisation of the web server documentation.
 
+## Examples of Other Documentations that uses this template
+
+- [IndEAA (Industrial Engineers Australia Assessment) Web Application](https://indeaa-docs.systemhealthlab.com/) used for streamlining course accreditation review
+- [ASER (Asset Equipment Registry) Web Application](https://aser-docs.systemhealthlab.com/) used for accessible equipment registry 
+- [Living Lab UWA Documentation](https://docs.livinglabproject.com/) used for technical documentation on accelerated life testing
+
 ## Why documentation?
 Part of the success of every project is its maintainability, and that means that ability to pass on the knowledge and technical details to the people that will carry on the work.
 
@@ -92,7 +98,14 @@ pip install -r requirements.txt
 
 This template is made to be simple such that it gives you a brief overview of how you would be writing your documentation with a few configuration. This is the type of documentation that you just build on top of.
 
-If in the scenario that you feel that I missed that is essential to be in the template, please feel free to give this repository a pull request. However, if you feel that you would like to extend this template much more, I would highly recommend to visit the original [Mkdocs Material Documentation](https://squidfunk.github.io/mkdocs-material/customization/).
+If in the scenario that you feel that I missed that is essential to be in the template, please see [Contributions Section](contributions.md). However, if you feel that you would like to extend this template much more, I would highly recommend to visit the original [Mkdocs Material Documentation](https://squidfunk.github.io/mkdocs-material/customization/).
+
+### Contributors
+All thanks to the following contributors for maintaining this:
+
+- [Frinze Lapuz](https://frinzelapuz.vercel.app/)
+- [Ben Travaglione](https://travaglione.com/)
+- [Melinda Hodkiewicz](https://systemhealthlab.com/about/current-members/)
 
 
 ## About this tutorial

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,10 +7,26 @@ For full documentation visit:
 - [PyMdown Extensions](https://facelessuser.github.io/pymdown-extensions/) for the different extensions that are installed
 - [MkDocs Material](https://squidfunk.github.io/mkdocs-material/) for the customisation of the web server documentation.
 
+## Why documentation?
+Part of the success of every project is its maintainability, and that means that ability to pass on the knowledge and technical details to the people that will carry on the work.
+
+## What is Markdown and what is Mkdocs?
+Markdown is a simplistic markup language that is used to write documentations with a file that ends with `.md`. The greatest thing about markdown is its simplicity, this allows it to be rendered in many formats - `.docx`, `.pdf`, `.tex`, and with the case of Mkdocs, to render websites. Mkdocs is simply a renderer for markdown that generates files essential for websites (HTML, CSS, JS). These files allows the possiblity of deploying markdown documents into your own websites (in servers or external providers such as github pages).
+
+There are a lot of places to learn how to write markdown, and due to its simplistic design, it is relatively easy to learn. Below the summary of a [guide](https://guides.github.com/features/mastering-markdown/#syntax) made by Github.
+
+???+ note "Alternative"
+    There are a lot of alternatives with MkDocs in the realms of markdown-based documentation such as [gitbook](https://www.gitbook.com/), [confluence](https://www.atlassian.com/software/confluence), [github wiki](https://docs.github.com/en/communities/documenting-your-project-with-wikis/about-wikis), and [docusaurus](https://docusaurus.io/).
+
+    In the side of other ways for documentation:
+
+        - Onenote
+        - Word Documents in OneDrive/Google Drive
+
 ## What do I hope to achieve with this tutorial and template?
 This tutorial and template has 2 main purpose:
 
-1. Make the documentation setup easier and accesible for everyone (template)
+1. Make the documentation setup easier and accessible for everyone (template)
 2. Teach Markdown (tutorial)
 
 ## How easy is this to deploy?
@@ -20,7 +36,7 @@ This tutorial and template has 2 main purpose:
 2. Delete the markdown files here and replace it with your own
 3. Change a couple of things in the `mkdocs.yml` file (there are comments around it to make it easier)
 4. Modify the `nav` in the `mkdocs.yml` file or delete it (Mkdocs will sort you documentation files to display)
-5. Deploy somewhere ! (easist way Github Pages see [here](#commands))
+5. Deploy somewhere ! (easiest way is with Github Pages see [here](#commands))
    
 
 ## Installation
@@ -28,6 +44,9 @@ Install this preferably in your global environment because this is just a code g
 ```
 pip install -r requirements.txt
 ```
+
+???+ note "Prerequisite"
+    You need to make sure that you have Python installed to be able to use `pip`. Here is the download [link](https://www.python.org/downloads/).
 ## Commands
 
 * `mkdocs new [dir-name]` - Create a new project.

--- a/docs/writing_markdown.md
+++ b/docs/writing_markdown.md
@@ -1,10 +1,4 @@
 # Writing Markdown
-
-## What is Markdown and what is Mkdocs?
-Markdown is a simplistic markup language that is used to write documentations with a file that ends with `.md`. The greatest thing about markdown is its simplicity, this allows it to be rendered in many formats - `.docx`, `.pdf`, `.tex`, and with the case of Mkdocs, to render websites. Mkdocs is simply a renderer for markdown that generates files essential for websites (HTML, CSS, JS). These files allows the possiblity of deploying markdown documents into your own websites (in servers or external providers such as github pages).
-
-There are a lot of places to learn how to write markdown, and due to its simplistic design, it is relatively easy to learn. Below the summary of a [guide](https://guides.github.com/features/mastering-markdown/#syntax) made by Github
-
 ## Github Guide
 
 Here’s an overview of Markdown syntax that you can use anywhere on GitHub.com or in your own text files.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
 - Writing Markdown: writing_markdown.md
 - Flavoured Markdown: flavoured_markdown.md
 - Deployment and Automated Site Deployment: deployment_and_automated_site_deployment.md
+- Contributions: contributions.md
 # You can also create folder/file structure by following this syntax
 # - Folder:
 #   - Files : <Insert File here>


### PR DESCRIPTION
For future note, there are two branches for this is:

- `main` is the version deployed in github pages
- `template` is the version that can be used as a template

The reason why this is separate is to enable the ability to add details in `main` such as CNAME, and google analytics (possibly in the future) without the `template` to have it. This is for functionality purposes in order to avoid the same repository in uwasystemhealth.github.io having the same CNAME, or future template to have the same google analytics ID